### PR TITLE
Fix the build - and implement tsc on PR's

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,31 @@
+name: PR
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+     strategy:
+      matrix:
+        node-version: [16.x]
+
+    
+    env:
+      CI: true
+      NODE_OPTIONS: --max-old-space-size=4096
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+    - name: Set up Node.js
+      uses: actions/setup-node@main
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn install --frozen-lockfile
+    - name: build type declarations
+      run: yarn tsc

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,9 +10,9 @@ jobs:
   sync:
     runs-on: ubuntu-latest
 
-     strategy:
-      matrix:
-        node-version: [16.x]
+    strategy:
+     matrix:
+       node-version: [16.x]
 
     
     env:

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -16,12 +16,12 @@
     "build-image": "docker build ../.. -f Dockerfile --tag backstage"
   },
   "dependencies": {
-    "app": "link:../app",
     "@backstage/backend-common": "^0.18.3",
     "@backstage/backend-tasks": "^0.5.0",
-    "@backstage/catalog-model": "^1.0.1",
     "@backstage/catalog-client": "^1.0.1",
+    "@backstage/catalog-model": "^1.0.1",
     "@backstage/config": "^1.0.0",
+    "@backstage/integration": "^1.4.3",
     "@backstage/plugin-app-backend": "^0.3.31",
     "@backstage/plugin-auth-backend": "^0.18.1",
     "@backstage/plugin-catalog-backend": "^1.1.0",
@@ -32,11 +32,12 @@
     "@backstage/plugin-search-backend": "^1.2.4",
     "@backstage/plugin-search-backend-node": "^1.1.4",
     "@backstage/plugin-techdocs-backend": "^1.1.0",
+    "app": "link:../app",
+    "better-sqlite3": "^7.5.0",
     "dockerode": "^3.3.1",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "luxon": "^2.0.2",
-    "better-sqlite3": "^7.5.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -2,8 +2,6 @@ import { CatalogClient } from '@backstage/catalog-client';
 import { createRouter, createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
 import { Router } from 'express';
 import type { PluginEnvironment } from '../types';
-
-
 import { dotnetNewAction, dotnetBuildAction, dotnetInstallTemplateAction , dotnetNugetAddAction} from '../../../../plugins/plugin-scaffolder-dotnet-backend'
 import { ScmIntegrations } from '@backstage/integration';
 

--- a/plugins/plugin-scaffolder-dotnet-backend/package.json
+++ b/plugins/plugin-scaffolder-dotnet-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plusultra/plugin-scaffolder-dotnet-backend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/plugin-scaffolder-dotnet-backend/package.json
+++ b/plugins/plugin-scaffolder-dotnet-backend/package.json
@@ -28,7 +28,8 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend": "^1.1.0"
+    "@backstage/plugin-scaffolder-backend": "^1.1.0",
+    "@backstage/plugin-scaffolder-node": "^0.1.1"
   },
   "devDependencies": {
     "@backstage/backend-common": "^0.18.3",

--- a/plugins/plugin-scaffolder-dotnet-backend/src/actions/dotnet-build/dotnetbuild.ts
+++ b/plugins/plugin-scaffolder-dotnet-backend/src/actions/dotnet-build/dotnetbuild.ts
@@ -1,5 +1,6 @@
 import { executeShellCommand } from '@backstage/plugin-scaffolder-backend';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+
 export const dotnetBuildAction = () => {
   return createTemplateAction<{ args?: string[] }>({
     id: 'dotnet:build',

--- a/plugins/plugin-scaffolder-dotnet-backend/src/actions/dotnet-nuget-source-add/dotnetnuget.ts
+++ b/plugins/plugin-scaffolder-dotnet-backend/src/actions/dotnet-nuget-source-add/dotnetnuget.ts
@@ -1,10 +1,6 @@
-import { executeShellCommand } from '@backstage/plugin-scaffolder-backend';
-import { resolveSafeChildPath } from '@backstage/backend-common';
 import { InputError } from "@backstage/errors";
-
-import { Config } from "@backstage/config";
 import { ScmIntegrationRegistry } from "@backstage/integration";
-import { spawn, SpawnOptionsWithoutStdio } from 'child_process';
+import { spawn } from 'child_process';
 
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 
@@ -34,7 +30,7 @@ export const dotnetNugetAddAction = (options: {
             },
         },
         async handler(ctx) {
-            //TODO: switch on incoming host to select integration
+            // TODO: switch on incoming host to select integration
             const host = "github.com";
             const integrationConfig = integrations.github.byHost(host);
       
@@ -50,7 +46,7 @@ export const dotnetNugetAddAction = (options: {
       
             const token = integrationConfig.config.token!;
             // This allows adding of nuget 
-            var arg = ['nuget', 'add', 'source', ctx.input.packageSource, '-u', 'backstage', '-p', token, '--store-password-in-clear-text']
+            const arg = ['nuget', 'add', 'source', ctx.input.packageSource, '-u', 'backstage', '-p', token, '--store-password-in-clear-text']
             
             const process = spawn('dotnet', arg);
 
@@ -69,9 +65,8 @@ export const dotnetNugetAddAction = (options: {
         
             process.on('close', code => {
               if (code !== 0) {
-                ctx.logStream.write(code.toString());
+                ctx.logStream.write(code?.toString());
               }
-             
             });
 
 
@@ -79,14 +74,3 @@ export const dotnetNugetAddAction = (options: {
         },
     });
 };
-
-function stringify(value: any) {
-    switch (typeof value) {
-        case 'string': return value;
-        case 'object': return JSON.stringify(value);
-        default: return String(value);
-    }
-};
-
-
- 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7304,7 +7304,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17":
+"@types/react-dom@*", "@types/react-dom@<18.0.0":
   version "17.0.16"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.16.tgz#7caba93cf2806c51e64d620d8dff4bae57e06cc4"
   integrity sha512-DWcXf8EbMrO/gWnQU7Z88Ws/p16qxGpPyjTKTpmBSFKeE+HveVubqGO1CVK7FrwlWD5MuOcvh8gtd0/XO38NdQ==


### PR DESCRIPTION
Hey, 

I noticed my previous PR broke the build as I didn't run `yarn tsc`.

In this PR I have:

 - fixed the `yarn tsc` errors
 - Bumped the plugin version to 1.1.2 (intention is so that it get published to npm)
 - Added a workflow file for PR checks - starting with `yarn tsc` validation. 
 

Here's a the PR being merged into my forks master all building okay https://github.com/Phiph/plusultra-dotnet-backstage-plugins/actions/runs/4521025664

